### PR TITLE
Updated buttons and fbar shortcuts to not reference toolbar object

### DIFF
--- a/src/providers/sencha/adapters_extjs/panel.js
+++ b/src/providers/sencha/adapters_extjs/panel.js
@@ -53,10 +53,10 @@ glu.regAdapter('panel', {
             defaultType : 'button',
             items : value,
             dock : 'bottom',
-            layout : Ext.applyIf(toolbar.layout || {}, {
+            layout : {
                 // default to 'end' (right-aligned)
                 pack : 'end'
-            })
+            }
         }
     },
 
@@ -66,10 +66,10 @@ glu.regAdapter('panel', {
             defaultType : 'button',
             items : value,
             dock : 'bottom',
-            layout : Ext.applyIf(toolbar.layout || {}, {
+            layout : {
                 // default to 'end' (right-aligned)
                 pack : 'end'
-            })
+            }
         }
     },
 


### PR DESCRIPTION
When we reference the object that doesn't exist, IE dies a horrible death.  This removes the toolbar.layout reference since it wasn't populated anyway and now properly works with IE.
