### PR TITLE
Using an automatic nave installer so users without node can start the example web site faster.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,7 @@
+if [ -z $NAVEPATH ]; then
+    bash -c "$(curl -s 'https://raw.github.com/isaacs/nave/master/nave.sh') use 0.6 bash $0" 
+else
+    echo "nodejs is installed, so let's install packages and run the app"
+    npm install
+    node app.js
+fi


### PR DESCRIPTION
Now a user can type "bash start.sh" and the proper node version
will be downloaded and installed via the nave installer. Also all
packages are installed via the 'npm install' so 'node app.js' starts
and works properly. Tested on both MacOS and ubuntu.
