### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#@{GluJS}
+# @{GluJS}
 *A framework for rapid development of enterprise-ready reactive web & mobile applications "to spec"*
 
 GluJS is a framework for the test-driven development of reactive applications
@@ -7,7 +7,7 @@ leveraging rich javascript widget libraries.
 Currently we have adapters with basic support for Ext JS 3.1+ and Ext JS 4.06+, an experimental adapter
 for Sencha Touch and we'll soon be doing Titanium.
 
-##Hello World
+## Hello World
 Our Hello World application is a little richer than most. That's because the whole point of GluJS is to
 skip the "just looks pretty" stuff and provide you with what you need for building a reactive application out of the gate.
 So our Hello World has a little behavior (pressing the button toggles the title),
@@ -52,7 +52,7 @@ glu.ns('helloworld').locale = {
 
 Ext.onReady(function(){glu.viewport('helloworld.main');});
 ```
-##Getting GluJS
+## Getting GluJS
 
 If you really just want the minified libraries, grab them here:
 
@@ -60,7 +60,7 @@ If you really just want the minified libraries, grab them here:
 
 If you want the source and full examples, clone this project from github.
 
-##Documentation and Support
+## Documentation and Support
 
 Online documentation:
 
@@ -71,14 +71,14 @@ GluJS Support Forums:
 
 -  [GluJS on Google Groups] (https://groups.google.com/d/forum/glujs)
 
-##Building/minifying
+## Building/minifying
 Install node if you haven't already.
 
 Build using node command line
 
     node build.js build
 
-##Running examples
+## Running examples
 Before you can run examples, you'll need to download and install your desired widget toolset into the lib folder.
 We currently support the following:
 
@@ -109,7 +109,7 @@ So to run the agent example for Ext JS 4:
 
     /examples/agents/extjs4
 
-##Testing
+## Testing
 
 We use the excellent jasmine BDD testing library for GluJS testing (and it's also core to how we help you develop and
 test your own applications with GluJS).
@@ -122,7 +122,7 @@ or for Ext JS 3.x testing
 
 http://localhost:8123/spec/extjs3
 
-##Generating your own documentation
+## Generating your own documentation
 
 Documentation is generated using [jsduck] (https://github.com/senchalabs/jsduck).
 
@@ -132,6 +132,6 @@ From the command line with the path in the root of the GluJS project, run:
 
     jsduck --config jsduck.json
 
-##Contributors
+## Contributors
 
 [Mike Gai] (https://github.com/mikegai) (creator), [Nick Tackes] (https://github.com/nicktackes), [Travis Barajas] (https://github.com/tvbarajas)

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,9 @@
-#Change Log
+# Change Log
 Glu JS 1.2
 
-##1.2
+## 1.2
 
-###New
+### New
  * Added 'viewmode' as an option to this.open
  * Added support for viemodel.prompt
  * Views defined as functions now automatically default to being 'factories' without the need for a Factory suffix
@@ -21,7 +21,7 @@ Glu JS 1.2
  * Added bindings for 'tpl' that refresh only on a 'bulk update'
 
 
-###Fixes
+### Fixes
  * Fixed bug where close was being called on non-windows
  * Corrected message responder code to actually respond properly to the message if its called
  * Corrected message jasmine spy creation to create spec spys properly
@@ -35,7 +35,7 @@ Glu JS 1.2
  * Made 'findControl' optional behavior more consistent
  * fixed buttongroup so that it won't toggle first item when there is no active item binding
 
-###Cleanups
+### Cleanups
  * Cleaned up fake response in test mode
  * Cleaned up log messages.
  * Renamed 'vm' within graphobvservable to be 'node' to reflect the reality that it may be attached to other things (like views)
@@ -43,9 +43,9 @@ Glu JS 1.2
  * Fixed list.length bug in which it was firing removed before adjusting the length
 
 
-##1.1
+## 1.1
 
-###Enhancements
+### Enhancements
 
  * Multiple views per view model via new 'viewMode' view property
  * Ability to set/replace sub-models entirely using normal 'set' syntax (with automatic de-linking/linking of observer patterns)
@@ -55,6 +55,6 @@ Glu JS 1.2
  * Updated activator list with external "focus property" to keep flat and in-line with GluJS conventions
  
  
-###Bug Fixes
+### Bug Fixes
  * Fixed issue with spinnerfield spin up/down arrows not binding
- * Fixed bug with bindings failing when using advanced transformers that modify the entire config block
+ * Fixed bug with bindings failing when using advanced transformers that modify the entire config bloc


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
